### PR TITLE
Fix about page JSON fallback import

### DIFF
--- a/src/app/(pages)/about/page.tsx
+++ b/src/app/(pages)/about/page.tsx
@@ -55,8 +55,9 @@ export default function AboutPage() {
         console.error("Error fetching about data:", error);
         
         // For development, use the local data directly
-        import('../../data/about.json').then((data) => {
-          setAboutData(data);
+        import('../../data/about.json').then((module) => {
+          // Dynamic JSON imports return a module object with the data on `default`
+          setAboutData(module.default);
           setIsLoaded(true);
         });
       }


### PR DESCRIPTION
## Summary
- fix dynamic import to correctly load about data JSON when API fetch fails

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6895ea78a6b8832ebea5f71964e3e2b0